### PR TITLE
Fix CV download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
       <p>Game & Level Designer passionate about creating immersive worlds and engaging gameplay experiences.</p>
       <div class="hero-buttons">
         <a href="#projects" class="btn btn-primary">View My Work</a>
-        <button class="btn btn-cv"><i class="fas fa-download"></i> Download CV</button>
+        <a href="Downloads/Luca_Frincu_CV.pdf" class="btn btn-cv" download target="_blank"><i class="fas fa-download"></i> Download CV</a>
       </div>
       <div class="social-links">
         <a href="https://github.com/LucaFrincu" target="_blank" data-tooltip="GitHub"><i class="fab fa-github"></i></a>
@@ -700,9 +700,9 @@
   </footer>
 
   <!-- FLOATING CV -->
-  <button class="floating-cv btn-cv">
+  <a href="Downloads/Luca_Frincu_CV.pdf" class="floating-cv btn-cv" download target="_blank">
     <i class="fas fa-file-pdf"></i> <span>Download CV</span>
-  </button>
+  </a>
 
   <!-- BACK TO TOP -->
   <a href="#" id="backToTop" class="back-to-top"><i class="fas fa-arrow-up"></i></a>


### PR DESCRIPTION
## Summary
- convert hero and floating CV buttons to links
- point links to `Downloads/Luca_Frincu_CV.pdf`

## Testing
- `python3 -m http.server 8000` (manual check via curl)

------
https://chatgpt.com/codex/tasks/task_e_687e54fa9f208331820892a6c3395599